### PR TITLE
Support user defined MySQL Port/Socket in API

### DIFF
--- a/web/api/app/Config/database.php.default
+++ b/web/api/app/Config/database.php.default
@@ -67,7 +67,6 @@ class DATABASE_CONFIG {
 	public $default = array(
 		'datasource' => 'Database/Mysql',
 		'persistent' => false,
-		'host' => ZM_DB_HOST,
 		'login' => ZM_DB_USER,
 		'password' => ZM_DB_PASS,
 		'database' => ZM_DB_NAME,
@@ -85,4 +84,18 @@ class DATABASE_CONFIG {
 		'prefix' => '',
 		//'encoding' => 'utf8',
 	);
+
+	public function __construct() {
+		if (strpos(ZM_DB_HOST, ':')):
+			$array = explode(':', ZM_DB_HOST, 2);
+                        if (is_numeric($array[1])):
+				$this->default['host'] = $array[0];
+				$this->default['port'] = $array[1];
+			else:
+				$this->default['unix_socket'] = $array[1];
+			endif;
+		else:
+			$this->default['host'] = ZM_DB_HOST;
+		endif;
+	}
 }


### PR DESCRIPTION
I tested this working properly with the following use cases

```
ZM_DB_HOST=localhost
ZM_DB_HOST=localhost:/tmp/mysql2.sock
ZM_DB_HOST=127.0.0.1:3307
```

Do note, that "localhost:3307" doesn't work but this is a CakePHP/PDO issue, we are passing the parameters correctly. If someone wants to use a TCP port on their local machine, they should not use "localhost" but instead "127.0.0.1"
