### PR TITLE
Storageareas webfixes

### DIFF
--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -130,8 +130,9 @@ if ( canEdit( 'Events' ) ) {
 ?>
         <div id="deleteEvent"><a href="#" onclick="deleteEvent()"><?php echo translate('Delete') ?></a></div>
         <div id="editEvent"><a href="#" onclick="editEvent()"><?php echo translate('Edit') ?></a></div>
-        <div id="archiveEvent" class="hidden"><a href="#" onclick="archiveEvent()"><?php echo translate('Archive') ?></a></div>
-        <div id="unarchiveEvent" class="hidden"><a href="#" onclick="unarchiveEvent()"><?php echo translate('Unarchive') ?></a></div>
+        <div id="archiveEvent"<?php if ( $Event->Archived == 1 ){echo " class=\"hidden\">";}else{echo ">";} ?><a href="#" onclick="archiveEvent()"><?php echo translate('Archive') ?></a></div>
+        <div id="unarchiveEvent"<?php if ( $Event->Archived == 0 ){echo " class=\"hidden\">";}else{echo">";} ?><a href="#" onclick="unarchiveEvent()"><?php echo translate('Unarchive') ?></a></div>
+</div>
 <?php 
 } // end if can edit Events
   if ( $Event->DefaultVideo() ) { ?>

--- a/web/skins/classic/views/js/montagereview.js
+++ b/web/skins/classic/views/js/montagereview.js
@@ -492,7 +492,7 @@ function clicknav(minSecs,maxSecs,arch,live) {// we use the current time if we c
     if ( monitorZoomScale[monitorPtr[i]] < 0.99 || monitorZoomScale[monitorPtr[i]] > 1.01 )  // allow for some up/down changes and just treat as 1 of almost 1
       zoomStr += "&z" + monitorPtr[i].toString() + "=" + monitorZoomScale[monitorPtr[i]].toFixed(2);
 
-  var uri = "?view=" + currentView + fitStr + groupStr + minStr + maxStr + currentStr + intervalStr + liveStr + zoomStr + "&scale=" + document.getElementById("scaleslider").value + "&speed=" + speeds[$j("#speedslider").value];
+  var uri = "?view=" + currentView + fitStr + groupStr + minStr + maxStr + currentStr + intervalStr + liveStr + zoomStr + "&scale=" + document.getElementById("scaleslider").value + "&speed=" + document.getElementById("speedslider").value;
   window.location = uri;
 }
 

--- a/web/skins/classic/views/storage.php
+++ b/web/skins/classic/views/storage.php
@@ -56,7 +56,7 @@ xhtmlHeaders(__FILE__, translate('Storage')." - ".$newStorage['Name'] );
             </tr>
             <tr>
               <th scope="row"><?php echo translate('Path') ?></th>
-              <td><input type="url" name="newStorage[Path]" value="<?php echo $newStorage['Path'] ?>"/></td>
+              <td><input type="text" name="newStorage[Path]" value="<?php echo $newStorage['Path'] ?>"/></td>
             </tr>
           </tbody>
         </table>


### PR DESCRIPTION
The archive button remained hidden on the event view because the javascript to control it doesn't fire on page load.  I'm not sure how it's intended to work but the javascript doesn't even have access to that event information and everything else in that menu gets its control from php so I added that for the archive link.  

The speed slider wasn't working on montagereview if you chose either 1 Hour or 8 Hour.  I changed it back from some jquery logic since it wasn't working and the scale slider didn't use jquery.

The storage path text box was set as type url so it wouldn't accept regular unix style file paths.  Changing it to text allows local storage to be added.