### PR TITLE
Webfixes2

### DIFF
--- a/web/ajax/status.php
+++ b/web/ajax/status.php
@@ -367,7 +367,7 @@ function getNearEvents() {
   else
     $midSql = '';
 
-  $sql = "select E.Id as Id from Events as E inner join Monitors as M on E.MonitorId = M.Id where ".dbEscape($sortColumn)." ".($sortOrder=='asc'?'<=':'>=')." '".$event[$_REQUEST['sort_field']]."'".$_REQUEST['filter']['sql'].$midSql." order by $sortColumn ".($sortOrder=='asc'?'desc':'asc');
+  $sql = "select E.Id as Id from Events as E inner join Monitors as M on E.MonitorId = M.Id where $sortColumn ".($sortOrder=='asc'?'<=':'>=')." '".$event[$_REQUEST['sort_field']]."'".$_REQUEST['filter']['sql'].$midSql." order by $sortColumn ".($sortOrder=='asc'?'desc':'asc');
   $result = dbQuery( $sql );
   while ( $id = dbFetchNext( $result, 'Id' ) ) {
     if ( $id == $eventId ) {

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -132,7 +132,6 @@ if ( canEdit( 'Events' ) ) {
         <div id="editEvent"><a href="#" onclick="editEvent()"><?php echo translate('Edit') ?></a></div>
         <div id="archiveEvent"<?php if ( $Event->Archived == 1 ){echo " class=\"hidden\">";}else{echo ">";} ?><a href="#" onclick="archiveEvent()"><?php echo translate('Archive') ?></a></div>
         <div id="unarchiveEvent"<?php if ( $Event->Archived == 0 ){echo " class=\"hidden\">";}else{echo">";} ?><a href="#" onclick="unarchiveEvent()"><?php echo translate('Unarchive') ?></a></div>
-</div>
 <?php 
 } // end if can edit Events
   if ( $Event->DefaultVideo() ) { ?>

--- a/web/skins/classic/views/js/montagereview.js
+++ b/web/skins/classic/views/js/montagereview.js
@@ -492,7 +492,7 @@ function clicknav(minSecs,maxSecs,arch,live) {// we use the current time if we c
     if ( monitorZoomScale[monitorPtr[i]] < 0.99 || monitorZoomScale[monitorPtr[i]] > 1.01 )  // allow for some up/down changes and just treat as 1 of almost 1
       zoomStr += "&z" + monitorPtr[i].toString() + "=" + monitorZoomScale[monitorPtr[i]].toFixed(2);
 
-  var uri = "?view=" + currentView + fitStr + groupStr + minStr + maxStr + currentStr + intervalStr + liveStr + zoomStr + "&scale=" + document.getElementById("scaleslider").value + "&speed=" + document.getElementById("speedslider").value;
+  var uri = "?view=" + currentView + fitStr + groupStr + minStr + maxStr + currentStr + intervalStr + liveStr + zoomStr + "&scale=" + scale[$j("#scaleslider")[0].value] + "&speed=" + speeds[$j("#speedslider")[0].value];
   window.location = uri;
 }
 


### PR DESCRIPTION
I messed up my last push.  Somehow let an extra /div slip in.  Sorry.  This also changes both of the sliders in montagereview.js to jquery.  

The ajax function getNearEvents always returns 0 as the previous event.  Its sortcolumn is escaped unlike the next event sortcolumn.  This breaks it, but I'm not sure why they were different.  It looks like it's a change from 2008 so I don't think anyone cares or it's due to some change in mysql behavior.  It behaves the same on both ubuntu storageareas and standard 1.30.4 on fedora so I'm assuming it's not just my local settings.  