### PR TITLE
Fix nearevents path

### DIFF
--- a/web/ajax/status.php
+++ b/web/ajax/status.php
@@ -390,8 +390,8 @@ function getNearEvents() {
   $result['NextEventId'] = empty($nextEvent)?0:$nextEvent['Id'];
   $result['PrevEventStartTime'] = empty($prevEvent)?0:$prevEvent['StartTime'];
   $result['NextEventStartTime'] = empty($nextEvent)?0:$nextEvent['StartTime'];
-  $result['PrevEventDefVideoPath'] = empty($prevEvent)?0:(getEventDefaultVideoPath($prevEvent));
-  $result['NextEventDefVideoPath'] = empty($nextEvent)?0:(getEventDefaultVideoPath($nextEvent));
+  $result['PrevEventDefVideoPath'] = empty($prevEvent)?0:(getEventDefaultVideoPath($prevEvent['Id']));
+  $result['NextEventDefVideoPath'] = empty($nextEvent)?0:(getEventDefaultVideoPath($nextEvent['Id']));
   return( $result );
 }
 

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -471,7 +471,7 @@ function getEventPath( $event ) {
 
 function getEventDefaultVideoPath( $event ) {
   $Event = new Event( $event );
-  return $Event->getStreamSrc( array( "mode=mpeg&format=h264" ) );
+  return $Event->getStreamSrc( array( "mode"=>"mpeg", "format"=>"h264" ) );
   //$Event->Path().'/'.$event['DefaultVideo'];
 }
 


### PR DESCRIPTION
When this is called it throws Undefined property: Event::$DefaultVideo errors.  It's trying to pass an array to the Event constructor so it winds up with incomplete information.  This makes it get the nph-zms path from geteventsrc instead of the video.js path since it lacks the DefaultVideo path.   