### PR TITLE
fix rescale for video.js

### DIFF
--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -47,15 +47,16 @@ function changeScale() {
   var newWidth = ( baseWidth * scale ) / SCALE_BASE;
   var newHeight = ( baseHeight * scale ) / SCALE_BASE;
 
-	if ( vid ) {
-    // Using video.js
-		vid.width = newWidth;
-		vid.height = newHeight;
-	} else {
+  if ( vid ) {
+  // Using video.js
+    Cookie.write( 'zmEventScale'+eventData.MonitorId, scale, { duration: 10*365 } );
+    location.reload(true);
+    return;
+  } else {
     streamScale( scale );
-		var streamImg = document.getElementById('evtStream');
-		streamImg.style.width = newWidth + "px";
-		streamImg.style.height = newHeight + "px";
+    var streamImg = document.getElementById('evtStream');
+    streamImg.style.width = newWidth + "px";
+    streamImg.style.height = newHeight + "px";
     Cookie.write( 'zmEventScale'+eventData.MonitorId, scale, { duration: 10*365 } );
   }
 }


### PR DESCRIPTION
Set the cookie and reload the page rather than resize the video itself.  This works but isn't as quick as the way the non-video.js works.  The alarmcues react poorly to changing the div size in javascript since they are built in php.  I'll see if can do anything about that.