### PR TITLE
#25 fix multiselect delete for groups - rename gid to markGids

### DIFF
--- a/web/includes/actions.php
+++ b/web/includes/actions.php
@@ -615,13 +615,15 @@ Warning("Addterm");
       }
       $view = 'none';
     }
-    if ( !empty($_REQUEST['gid']) && $action == 'delete' ) {
-      dbQuery( 'DELETE FROM Groups WHERE Id = ?', array($_REQUEST['gid']) );
-      if ( isset($_COOKIE['zmGroup']) ) {
-        if ( $_REQUEST['gid'] == $_COOKIE['zmGroup'] ) {
-          unset( $_COOKIE['zmGroup'] );
-          setcookie( 'zmGroup', '', time()-3600*24*2 );
-          $refreshParent = true;
+    if ( !empty($_REQUEST['markGids']) && $action == 'delete' ) {
+      foreach( $_REQUEST['markGids'] as $markGid ) {
+        dbQuery( 'DELETE FROM Groups WHERE Id = ?', array($markGid) );
+        if ( isset($_COOKIE['zmGroup']) ) {
+          if ( $_REQUEST['gid'] == $_COOKIE['zmGroup'] ) {
+            unset( $_COOKIE['zmGroup'] );
+            setcookie( 'zmGroup', '', time()-3600*24*2 );
+            $refreshParent = true;
+          }
         }
       }
     }

--- a/web/skins/classic/views/groups.php
+++ b/web/skins/classic/views/groups.php
@@ -75,7 +75,7 @@ function group_line( $Group ) {
     $html .= validHtmlStr($Group->Name());
   }
   $html .= '</td><td class="colIds">'. monitorIdsToNames( $Group->MonitorIds(), 30 ).'</td>
-                <td class="colSelect"><input type="checkbox" name="gid" value="'. $Group->Id() .'" onclick="configureButtons(this);"/></td>
+                <td class="colSelect"><input type="checkbox" name="markGids[]" value="'. $Group->Id() .'" onclick="configureButtons(this);"/></td>
               </tr>
   ';
   if ( isset( $children[$Group->Id()] ) ) {


### PR DESCRIPTION
Included foreach to delete each selected group - matches the code style for deleting monitors.

Renamed gid to markGids[] to match the naming of markMids[] for monitors.