### PR TITLE
height 100 causing phantom scroll

### DIFF
--- a/web/skins/classic/css/flat/skin.css
+++ b/web/skins/classic/css/flat/skin.css
@@ -21,12 +21,7 @@
  * Primary look and feel styles
  */
 
-html {
-  height: 100%;
-}
-
 body {
-  height: 100%;
     font-family: "Open Sans", Verdana, Arial, Helvetica, sans-serif;
     font-size: 13px;
     color: #333333;


### PR DESCRIPTION
Fixes phantom scrollbar in flat skin.  

I'm not sure if there was a goal for this.  It isn't in any other skins and it causes the page to have a tiny amount of overflow no matter how big it is.  