### PR TITLE
MontageReview ordering

### DIFF
--- a/web/skins/classic/views/js/montagereview.js
+++ b/web/skins/classic/views/js/montagereview.js
@@ -551,7 +551,7 @@ function maxfit2(divW, divH) {
 
   var borders=-1;
 
-  monitorPtr.sort(compSize);
+  //monitorPtr.sort(compSize); //Sorts monitors by size in viewport.  If enabled makes captions not line up with graphs.  
 
   while(1) {
     if( maxScale - minScale < 0.01 ) break;


### PR DESCRIPTION
Round 2!

fixes #23 

This fixes captions reordering and graphs not by stopping anything from reordering.  This means the monitor views don't reorder on size either.  I have a fix that keeps monitor view reordering intact.  I think that's confusing because the monitor views don't match up with the graphs.  If you feel it's needed I think I could make everything reorder.