### PR TITLE
Fix error when creating DB with zm_create.sql

### DIFF
--- a/db/zm_create.sql.in
+++ b/db/zm_create.sql.in
@@ -600,7 +600,7 @@ CREATE TABLE `Storage` (
 --
 -- Create a default storage location
 --
-insert into Storage VALUES (NULL, '/var/cache/zoneminder/events', 'Default' );
+insert into Storage VALUES (NULL, '/var/cache/zoneminder/events', 'Default', 'local' );
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;


### PR DESCRIPTION
On Ubuntu 16.04, the following command:
`mysql -uroot -p < /usr/share/zoneminder/db/zm_create.sql`

Throws the following error:
`ERROR 1136 (21S01) at line 603: Column count doesn't match value count at row 1`

This is due to a missing column when inserting into the Storage table on line 603