### PR TITLE
progressBar and navigation

### DIFF
--- a/web/skins/classic/css/classic/views/event.css
+++ b/web/skins/classic/css/classic/views/event.css
@@ -176,22 +176,14 @@ span.noneCue {
 
 #progressBar {
     position: relative;
-    border: 1px solid #666666;
-    height: 15px;
-    margin: 0 auto;
+    top: -1.5em;
+    height: 1.5em;
+    margin: 0 auto -1.5em auto;
 }
 
 #progressBar .progressBox {
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    height: 15px;
-    background: #eeeeee;
-    border-left: 1px solid #999999;
-}
-
-#progressBar .complete {
-    background: #aaaaaa;
+    height: 1.5em;
+    background: rgba(170, 170, 170, .7);
 }
 
 #eventStills {

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -159,22 +159,14 @@ span.noneCue {
 
 #progressBar {
     position: relative;
-    border: 1px solid #666666;
-    height: 15px;
-    margin: 0 auto;
+    top: -1.5em;
+    height: 1.5em;
+    margin: 0 auto -1.5em auto;
 }
 
 #progressBar .progressBox {
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    height: 15px;
-    background: #eeeeee;
-    border-left: 1px solid #999999;
-}
-
-#progressBar .complete {
-    background: #aaaaaa;
+    height: 1.5em;
+    background: rgba(170, 170, 170, .7);
 }
 
 #eventStills {

--- a/web/skins/classic/css/flat/views/event.css
+++ b/web/skins/classic/css/flat/views/event.css
@@ -170,22 +170,14 @@ span.noneCue {
 
 #progressBar {
     position: relative;
-    border: 1px solid #666666;
-    height: 15px;
-    margin: 0 auto;
+    top: -1.5em;
+    height: 1.5em;
+    margin: 0 auto -1.5em auto;
 }
 
 #progressBar .progressBox {
-    position: absolute;
-    top: 0px;
-    left: 0px;
-    height: 15px;
-    background: #eeeeee;
-    border-left: 1px solid #999999;
-}
-
-#progressBar .complete {
-    background: #aaaaaa;
+    height: 1.5em;
+    background: rgba(170, 170, 170, .7);
 }
 
 #eventStills {

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -85,10 +85,6 @@ parseSort();
 parseFilter( $_REQUEST['filter'] );
 $filterQuery = $_REQUEST['filter']['query'];
 
-$panelSections = 40;
-$panelSectionWidth = (int)ceil(reScale($Event->Width(),$scale)/$panelSections);
-$panelWidth = ($panelSections*$panelSectionWidth-1);
-
 $connkey = generateConnKey();
 
 $focusWindow = true;
@@ -195,6 +191,10 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
   }
 } // end if stream method
 ?>
+        <div id="alarmCueJpeg" class="alarmCue" style="width: <?php echo reScale($Event->Width(), $scale);?>px;"></div>
+        <div id="progressBar" style="width: <?php echo reScale($Event->Width(), $scale);?>px;">
+          <div class="progressBox" id="progressBox" title="" style="width: 0%;"></div>
+        </div><!--progressBar-->
         <p id="dvrControls" class="dvrControls">
           <input type="button" value="&lt;+" id="prevBtn" title="<?php echo translate('Prev') ?>" class="inactive" onclick="streamPrev( true );"/>
           <input type="button" value="&lt;&lt;" id="fastRevBtn" title="<?php echo translate('Rewind') ?>" class="inactive" disabled="disabled" onclick="streamFastRev( true );"/>
@@ -212,12 +212,6 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
           <span id="progress"><?php echo translate('Progress') ?>: <span id="progressValue"></span>s</span>
           <span id="zoom"><?php echo translate('Zoom') ?>: <span id="zoomValue"></span>x</span>
         </div>
-        <div id="progressBar" class="invisible">
-<?php for ( $i = 0; $i < $panelSections; $i++ ) { ?>
-           <div class="progressBox" id="progressBox<?php echo $i ?>" title=""></div>
-<?php } ?>
-        </div><!--progressBar-->
-        <div id="alarmCueJpeg" class="alarmCue" style="width: <?php echo reScale($Event->Width(), $scale);?>px;"></div>
       </div><!--imageFeed-->
       </div>
 <?php } /*end if !DefaultVideo*/ ?>

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -820,10 +820,11 @@ function handleClick( event ) {
   var x = event.page.x - $(target).getLeft();
   var y = event.page.y - $(target).getTop();
 
-  if ( event.shift )
-    streamPan( x, y );
-  else
-    streamZoomIn( x, y );
+  if (event.shift) {
+    streamPan(x, y);
+  } else {
+    streamZoomIn(x, y);
+  }
 }
 
 function setupListener() {

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -182,13 +182,15 @@ function getCmdResponse( respObj, respText ) {
     streamCmdTimer = clearTimeout( streamCmdTimer );
 
   streamStatus = respObj.status;
+  if (streamStatus.progress > parseFloat(eventData.Length)) streamStatus.progress = parseFloat(eventData.Length); //Limit progress to reality
 
   var eventId = streamStatus.event;
-  if ( eventId != lastEventId ) {
+  if ( eventId != lastEventId && lastEventId != 0) { //Doesn't run on first load, prevents a double hit on event and nearEvents ajax
     eventQuery( eventId );
     initialAlarmCues(eventId);  //zms uses this instead of a page reload, must call ajax+render
     lastEventId = eventId;
   }
+  if (lastEventId == 0) lastEventId = eventId; //Only fires on first load.
   if ( streamStatus.paused == true ) {
     $('modeValue').set( 'text', 'Paused' );
     $('rate').addClass( 'hidden' );


### PR DESCRIPTION
Some navigation fixes/handling.  Condensed code and handles it if zms crashes for whatever reason.  We can always navigate now, as far as I can tell.  I can separate out these commits if you don't want the next one.

ZMS progressBar.  
Changed it to overlay alarmCues.  Changed it to be a simple percent based div that is more responsive on events longer than 40s.  It updates on the same 1 second interval it always has but it always moves rather than waiting for 1/40th to complete.  Seeking is more accurate as well.  Moved it up to the bottom of the video because that seems more intuitive to me.  

![progressbar](https://user-images.githubusercontent.com/31593470/31589521-ef7bdb98-b1d0-11e7-8c93-156605edd6e1.jpg)

