### PR TITLE
Ajax navigation and resizing

### DIFF
--- a/web/ajax/status.php
+++ b/web/ajax/status.php
@@ -108,6 +108,7 @@ $statusData = array(
                 "elements" => array(
                   "Id" => array( "sql" => "Events.Id" ),
                   "MonitorId" => true,
+                  "MonitorName" => array("sql" => "(SELECT Monitors.Name FROM Monitors WHERE Monitors.Id = Events.MonitorId)"),
                   "Name" => true,
                   "Cause" => true,
                   "StartTime" => true,

--- a/web/skins/classic/css/classic/views/event.css
+++ b/web/skins/classic/css/classic/views/event.css
@@ -1,6 +1,10 @@
-.vjsMessage {
-    font-size: 2em;
-    line-height: 1.5;
+#content .vjsMessage {
+    width: 100%;
+    position: absolute;
+    left: 0;
+    z-index: 10;
+    margin: 0;
+    font-size: 200%;
     color: white;
     background-color: black;
     display: inline-block;
@@ -40,6 +44,7 @@ span.noneCue {
 
 #eventVideo {
    display: inline-block;
+   postion: relative;
 }
 
 #menuBar1 {
@@ -112,6 +117,8 @@ span.noneCue {
 }
 
 #imageFeed {
+    display: inline-block;
+    position: relative;
     text-align: center;
 }
 

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -1,6 +1,10 @@
-.vjsMessage {
-    font-size: 2em;
-    line-height: 1.5;
+#content .vjsMessage {
+    width: 100%;
+    position: absolute;
+    left: 0;
+    z-index: 10;
+    margin: 0;
+    font-size: 200%;
     color: white;
     background-color: black;
     display: inline-block;
@@ -95,6 +99,8 @@ span.noneCue {
 }
 
 #imageFeed {
+    display: inline-block;
+    position: relative;
     text-align: center;
 }
 
@@ -255,7 +261,8 @@ span.noneCue {
 }
 
 #eventVideo {
-display: inline-block;
+    display: inline-block;
+    position: relative;
 }
 
 #thumbsKnob {

--- a/web/skins/classic/css/flat/views/event.css
+++ b/web/skins/classic/css/flat/views/event.css
@@ -1,6 +1,10 @@
-.vjsMessage {
-    font-size: 2em;
-    line-height: 1.5;
+#content .vjsMessage {
+    width: 100%;
+    position: absolute;
+    left: 0;
+    z-index: 10;
+    margin: 0;
+    font-size: 200%;
     color: white;
     background-color: black;
     display: inline-block;
@@ -100,6 +104,8 @@ span.noneCue {
     visibility: hidden;
 }
 #imageFeed {
+    display: inline-block;
+    position: relative;
     text-align: center;
 }
 
@@ -272,6 +278,7 @@ span.noneCue {
 }
 #eventVideo {
     display: inline-block;
+    position: relative;
 }
 
 #video-controls {

--- a/web/skins/classic/includes/config.php
+++ b/web/skins/classic/includes/config.php
@@ -31,6 +31,7 @@ $rates = array(
 );
 
 $scales = array(
+    'auto' => translate('Scale to Fit'),
     '' => translate('Fixed Width/Height'),
     '400' => '4x',
     '300' => '3x',
@@ -43,6 +44,8 @@ $scales = array(
     '25' => '1/4x',
     '12.5' => '1/8x',
 );
+
+if (isset($_REQUEST['view'])) unset($scales[$_REQUEST['view'] == 'event' ? '' : 'auto']); //Remove the option we aren't using on montage or event
 
 $bandwidth_options = array(
     'high' => translate('High'),

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -283,6 +283,17 @@ function convertLabelFormat(LabelFormat, monitorName){
 }
 
 function addVideoTimingTrack(video, LabelFormat, monitorName, duration, startTime){
+//This is a hacky way to handle changing the texttrack. If we ever upgrade vjs in a revamp replace this.  Old method preserved because it's the right way.
+  let cues = vid.textTracks()[0].cues();
+  let labelFormat = convertLabelFormat(LabelFormat, monitorName);
+  startTime = moment(startTime);
+
+  for (let i = 0; i <= duration; i++) {
+    cues[i] = {id: i, index: i, startTime: i, Ca: i+1, text: startTime.format(labelFormat)};
+    startTime.add(1, 's');
+  }
+}
+/*
 	var labelFormat = convertLabelFormat(LabelFormat, monitorName);
 	var webvttformat = 'HH:mm:ss.SSS', webvttdata="WEBVTT\n\n";
 
@@ -304,6 +315,7 @@ function addVideoTimingTrack(video, LabelFormat, monitorName, duration, startTim
 	track.src = 'data:plain/text;charset=utf-8,'+encodeURIComponent(webvttdata);
 	video.appendChild(track);
 }
+*/
 
 function changeGroup( e, depth ) {
   var group_id = $('group'+depth).get('value');

--- a/web/skins/classic/js/video-js-skin.css
+++ b/web/skins/classic/js/video-js-skin.css
@@ -14,7 +14,7 @@
   font-size: .3em;
 }
 
-.vjs-default-skin.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar.vjs-zm {
+.vjs-default-skin.vjs-has-started.vjs-user-inactive.vjs-playing .vjs-control-bar {
   visibility: visible;
   opacity: 1;
   bottom: -2em;

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -154,20 +154,11 @@ if ( $Event->DefaultVideo() ) {
         <div id="videoFeed">
           <video id="videoobj" class="video-js vjs-default-skin" width="<?php echo reScale( $Event->Width(), $scale ) ?>" height="<?php echo reScale( $Event->Height(), $scale ) ?>" data-setup='{ "controls": true, "playbackRates": [0.5, 1, 1.5, 2, 4, 8, 16, 32, 64, 128, 256], "autoplay": true, "preload": "auto", "plugins": { "zoomrotate": { "zoom": "<?php echo $Zoom ?>"}}}'>
           <source src="<?php echo $Event->getStreamSrc( array( 'mode'=>'mpeg','format'=>'h264' ) ); ?>" type="video/mp4">
+          <track id="monitorCaption" kind="captions" label="English" srclang="en" src='data:plain/text;charset=utf-8,"WEBVTT\n\n 00:00:00.000 --> 00:00:01.000 ZoneMinder"' default>
           Your browser does not support the video tag.
           </video>
         </div>
         <!--script>includeVideoJs();</script-->
-        <script type="text/javascript">
-        var LabelFormat = "<?php echo validJsStr($Monitor->LabelFormat())?>";
-        var monitorName = "<?php echo validJsStr($Monitor->Name())?>";
-        var duration = <?php echo $Event->Length() ?>, startTime = '<?php echo $Event->StartTime() ?>';
-
-        addVideoTimingTrack(document.getElementById('videoobj'), LabelFormat, monitorName, duration, startTime);
-
-        nearEventsQuery( eventData.Id );
-        vjsReplay(<?php echo (strtotime($Event->StartTime()) + $Event->Length())*1000 ?>);
-        </script>
 
       <p id="dvrControls" class="dvrControls">
         <input type="button" value="&lt;+" id="prevBtn" title="<?php echo translate('Prev') ?>" class="inactive" onclick="streamPrev( true );"/>

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -192,7 +192,7 @@ if ( ZM_WEB_STREAM_METHOD == 'mpeg' && ZM_MPEG_LIVE_FORMAT ) {
   }
 } // end if stream method
 ?>
-        <div id="alarmCueJpeg" class="alarmCue" style="width: <?php echo reScale($Event->Width(), $scale);?>px;"></div>
+        <div id="alarmCue" class="alarmCue" style="width: <?php echo reScale($Event->Width(), $scale);?>px;"></div>
         <div id="progressBar" style="width: <?php echo reScale($Event->Width(), $scale);?>px;">
           <div class="progressBox" id="progressBox" title="" style="width: 0%;"></div>
         </div><!--progressBar-->

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -44,7 +44,9 @@ if (isset($_REQUEST['rate'])) {
 
 if (isset($_REQUEST['scale'])) {
   $scale = validInt($_REQUEST['scale']);
-} else if ( isset( $_COOKIE['zmEventScale'.$Event->MonitorId()] ) ) {
+} else if (isset($_COOKIE['zmEventScaleAuto'])) { //If we're using scale to fit use it on all monitors
+  $scale = 'auto';
+} else if (isset($_COOKIE['zmEventScale'.$Event->MonitorId()])) {
   $scale = $_COOKIE['zmEventScale'.$Event->MonitorId()];
 } else {
   $scale = reScale( SCALE_BASE, $Monitor->DefaultScale(), ZM_WEB_DEFAULT_SCALE );

--- a/web/skins/classic/views/event.php
+++ b/web/skins/classic/views/event.php
@@ -36,12 +36,13 @@ if ( $user['MonitorIds'] ) {
 }
 $Monitor = $Event->Monitor();
 
-if ( isset( $_REQUEST['rate'] ) )
+if (isset($_REQUEST['rate'])) {
   $rate = validInt($_REQUEST['rate']);
-else
-  $rate = reScale( RATE_BASE, $Monitor->DefaultRate(), ZM_WEB_DEFAULT_RATE );
+} else {
+  $rate = reScale(RATE_BASE, $Monitor->DefaultRate(), ZM_WEB_DEFAULT_RATE);
+}
 
-if ( isset( $_REQUEST['scale'] ) ) {
+if (isset($_REQUEST['scale'])) {
   $scale = validInt($_REQUEST['scale']);
 } else if ( isset( $_COOKIE['zmEventScale'.$Event->MonitorId()] ) ) {
   $scale = $_COOKIE['zmEventScale'.$Event->MonitorId()];

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -53,20 +53,15 @@ function initialAlarmCues (eventId) {
   $j.getJSON("api/events/"+eventId+".json", setAlarmCues); //get frames data for alarmCues and inserts into html
 }
 
-function setAlarmCues (data) { 
+function setAlarmCues (data) {
   cueFrames = data.event.Frame;
   alarmSpans = renderAlarmCues();
-  if ( vid ) {
-    $j(".vjs-progress-control").append('<div class="alarmCue">' + alarmSpans +  '</div>');
-    $j(".vjs-control-bar").addClass("vjs-zm");
-  } else {
-    $j("#alarmCueJpeg").html(alarmSpans);
-  }
+  $j(".alarmCue").html(alarmSpans);
 }
 
 function renderAlarmCues () {
   if (cueFrames) {
-    var cueRatio = (vid ? $j("#videoobj").width() : $j("#evtStream").width()) / (cueFrames[cueFrames.length - 1].Delta * 100);//use videojs width or nph-zms width
+    var cueRatio = (vid ? $j("#videoobj").width() : $j("#evtStream").width()) / (cueFrames[cueFrames.length - 1].Delta * 100);//use videojs width or zms width
     var minAlarm = Math.ceil(1/cueRatio);
     var spanTimeStart = 0;
     var spanTimeEnd = 0;
@@ -123,6 +118,7 @@ function renderAlarmCues () {
         spanTime = spanTimeEnd - spanTimeStart;
         alarmed = 0;
         pix = Math.round(cueRatio * spanTime);
+        if (pixSkew >= .5 || pixSkew <= -.5) pix += Math.round(pixSkew);
         alarmHtml += '<span class="alarmCue" style="width: ' + pix + 'px;"></span>';
       }
     }
@@ -956,7 +952,6 @@ function initPage() {
     progressBarSeek ();
     streamCmdTimer = streamQuery.delay( 250 );
     eventQuery.pass( eventData.Id ).delay( 500 );
-    initialAlarmCues(eventData.Id); //call ajax+renderAlarmCues for nph-zms.  
 
     if ( canStreamNative ) {
       var streamImg = $('imageFeed').getElement('img');

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -429,10 +429,11 @@ function getEventResponse( respObj, respText ) {
   // Technically, events can be different sizes, so may need to update the size of the image, but it might be better to have it stay scaled...
   //var eventImg = $('eventImage');
   //eventImg.setStyles( { 'width': eventData.width, 'height': eventData.height } );
-  if (vid) {
+  if (vid && CurEventDefVideoPath) {
     vid.src({type: 'video/mp4', src: CurEventDefVideoPath}); //Currently mp4 is all we use
     initialAlarmCues(eventData.Id);//ajax and render, new event
     addVideoTimingTrack(vid, LabelFormat, eventData.MonitorName, eventData.Length, eventData.StartTime);
+    CurEventDefVideoPath = null;
   } else {
     drawProgressBar();
   }

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -742,6 +742,7 @@ function getActResponse( respObj, respText ) {
     return;
 
   if ( respObj.refreshParent )
+    if (refreshParent == false) refreshParent = true;  //Bypass filter window redirect fix.
     refreshParentWindow();
 
   if ( respObj.refreshEvent )

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -1,9 +1,10 @@
 var vid = null;
 
-function vjsReplay(endTime) {
-  var video = videojs('videoobj').ready(function(){
+function vjsReplay() {
+  vid.ready(function(){
     var player = this;
     player.on('ended', function() {
+      var endTime = (Date.parse(eventData.EndTime)).getTime();
       switch(replayMode.value) {
         case 'none':
           break;
@@ -12,19 +13,23 @@ function vjsReplay(endTime) {
           break;
         case 'all':
           if (nextEventId == 0) {
-            $j("#videoobj").html('<p class="vjsMessage">No more events</p>');
+            let overLaid = $j("#videoobj");
+            overLaid.append('<p class="vjsMessage" style="height: '+overLaid.height()+'px; line-height: '+overLaid.height()+'px;">No more events</p>');
           } else {
             var nextStartTime = nextEventStartTime.getTime(); //nextEventStartTime.getTime() is a mootools workaround, highjacks Date.parse
             if (nextStartTime <= endTime) {
              streamNext( true );
              return;
             }
-            $j("#videoobj").html('<p class="vjsMessage"></p>');
+            let overLaid = $j("#videoobj");
+            vid.pause();
+            overLaid.append('<p class="vjsMessage" style="height: '+overLaid.height()+'px; line-height: '+overLaid.height()+'px;"></p>');
             var gapDuration = (new Date().getTime()) + (nextStartTime - endTime);
+            let messageP = $j(".vjsMessage");
             var x = setInterval(function() {
               var now = new Date().getTime();
               var remainder = new Date(Math.round(gapDuration - now)).toISOString().substr(11,8);
-              $j(".vjsMessage").html(remainder + ' to next event.');
+              messageP.html(remainder + ' to next event.');
               if (remainder < 0) {
                 clearInterval(x);
                 streamNext( true );
@@ -927,6 +932,7 @@ function initPage() {
   if ($j('#videoobj').length) {
     vid = videojs("videoobj");
     initialAlarmCues(eventData.Id); //call ajax+renderAlarmCues after videojs is.  should be only call to initialAlarmCues on vjs streams
+    vjsReplay();
   }
   if (vid) {
 /*

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -924,11 +924,11 @@ function setupListener() {
 
 function initPage() {
   //FIXME prevent blocking...not sure what is happening or best way to unblock
-  if ( $('videoobj') ) {
+  if ($j('#videoobj').length) {
     vid = videojs("videoobj");
     initialAlarmCues(eventData.Id); //call ajax+renderAlarmCues after videojs is.  should be only call to initialAlarmCues on vjs streams
   }
-  if ( vid ) {
+  if (vid) {
 /*
     setupListener();
       vid.removeAttribute("controls");

--- a/web/skins/classic/views/js/event.js.php
+++ b/web/skins/classic/views/js/event.js.php
@@ -30,13 +30,18 @@ var eventData = {
     MonitorId: '<?php echo $Event->MonitorId() ?>',
     Width: '<?php echo $Event->Width() ?>',
     Height: '<?php echo $Event->Height() ?>',
-    Length: '<?php echo $Event->Length() ?>'
+    Length: '<?php echo $Event->Length() ?>',
+    StartTime: '<?php echo $Event->StartTime() ?>',
+    EndTime: '<?php echo $Event->EndTime() ?>',
+    MonitorName: '<?php echo $Monitor->Name() ?>'
 };
 
 var filterQuery = '<?php echo isset($filterQuery)?validJsStr(htmlspecialchars_decode($filterQuery)):'' ?>';
 var sortQuery = '<?php echo isset($sortQuery)?validJsStr(htmlspecialchars_decode($sortQuery)):'' ?>';
 
-var scale = <?php echo $scale ?>;
+var scale = "<?php echo $scale ?>";
+var LabelFormat = "<?php echo validJsStr($Monitor->LabelFormat())?>";
+
 var canEditEvents = <?php echo canEdit( 'Events' )?'true':'false' ?>;
 var streamTimeout = <?php echo 1000*ZM_WEB_REFRESH_STATUS ?>;
 


### PR DESCRIPTION
Nav nav more nav.  
Fixed a few edge cases with alarmCues overflowing and simplified it.  Revamped videojs replay and end of events messages to overlay the streams.  

Which allowed me to converge zms style and videojs style navigation a bit.  videojs streams now use ajax.  It's faster and feels smoother.  Added a watch for zms crashing so we can't get stuck.  Address bar stays synced with current event so if I'm wrong about that we can still refresh and move on.  

Scale to Fit is now a thing in event view.  Navigating through events of different dimensions was awful.  Now it can be set to fit the event to the page.  Once selected the setting applies to all events until any event turns it off.  Previous scale settings are preserved and it shouldn't affect anywhere else that scale is used.  

There's also a fix for deleting an event not refreshing the parent Events window.  It looks like a fix that mentions filter window broke this.  refreshParentWindow is used in several places.  This fix just forces event to use true for itself and nothing else.