### PR TITLE
Minor UI fixes

### DIFF
--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2067,7 +2067,7 @@ function cache_bust( $file ) {
   # Use the last modified timestamp to create a link that gets a different filename
   # To defeat caching.  Should probably use md5 hash
   $parts = pathinfo($file);
-  $cacheFile = 'cache/'.$parts['filename'].'-'.filemtime($file).'.'.$parts['extension'];
+  $cacheFile = 'cache/'.$parts['filename'].'-'.$_COOKIE['zmCSS'].'-'.filemtime($file).'.'.$parts['extension'];
   if ( file_exists( ZM_PATH_WEB.'/'.$cacheFile ) or symlink( ZM_PATH_WEB.'/'.$file, ZM_PATH_WEB.'/'.$cacheFile ) ) {
     return $cacheFile;
   } else {

--- a/web/includes/functions.php
+++ b/web/includes/functions.php
@@ -2198,6 +2198,7 @@ function getStreamMode( ) {
     $streamMode = 'single';
     Info( 'The system has fallen back to single jpeg mode for streaming. Consider enabling Cambozola or upgrading the client browser.' );
   }
+  return $streamMode;
 } // end function getStreamMode
 
 function folder_size($dir) {

--- a/web/skins/classic/css/classic/views/event.css
+++ b/web/skins/classic/css/classic/views/event.css
@@ -149,9 +149,9 @@ span.noneCue {
 }
 
 .dvrControls input {
-    height: 20px;
-    width: 28px;
-    padding-bottom: 3px;
+    height: 1.5em;
+    width: 2em;
+    padding: 0 ;
     margin: 0 3px;
 }
 

--- a/web/skins/classic/css/dark/skin.css
+++ b/web/skins/classic/css/dark/skin.css
@@ -518,7 +518,6 @@ input[type=submit]:disabled {
 .sidebar {
   position: absolute;
   top: 0;
-  bottom: 0;
   left: 0;
   z-index: 1000;
   display: block;

--- a/web/skins/classic/css/dark/views/event.css
+++ b/web/skins/classic/css/dark/views/event.css
@@ -131,9 +131,9 @@ span.noneCue {
 }
 
 .dvrControls input {
-    height: 20px;
-    width: 28px;
-    padding-bottom: 3px;
+    height: 1.5em;
+    width: 2em;
+    padding: 0;
     margin: 0 3px;
 }
 

--- a/web/skins/classic/views/options.php
+++ b/web/skins/classic/views/options.php
@@ -65,6 +65,7 @@ if ( $tab == 'skins' ) {
   $current_css = $_COOKIE['zmCSS'];
   if ( isset($_GET['css-choice']) and ( $_GET['css-choice'] != $current_css ) ) {
     setcookie('zmCSS',$_GET['css-choice'], time()+3600*24*30*12*10 );
+    array_map('unlink', glob(ZM_PATH_WEB.'/cache/*')); //cleanup symlinks from cache_bust
     //header("Location: index.php?view=options&tab=skins&reset_parent=1");
     $reload = true;
   }


### PR DESCRIPTION
Fixes dvrControls missing from watch view.  The function change in feature_h264 did not return any value.  

Fixes the sidebar on dark theme having a scrollbar.

Fixes classic and dark dvr buttons text centering.

Fixes cache_bust preventing css theme change.  The cache_bust function was preventing changing css theme because it would detect a valid symlink even though it didn't link to the correct file.  Removing the old symlinks fixed this issue.  The next issue was files in all three themes have the same names so a forced refresh was needed to actually load the new files.  In keeping with the whole point of cache_bust I added the theme name to the symlink from the cookie. 