### PR TITLE
Add navbar refresh to all pages that use it

### DIFF
--- a/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
+++ b/scripts/ZoneMinder/lib/ZoneMinder/ConfigData.pm.in
@@ -2934,6 +2934,16 @@ our @options = (
     category    => 'highband',
   },
   {
+    name        => 'ZM_WEB_H_REFRESH_NAVBAR',
+    default     => '5',
+    description => 'How often (in seconds) the navigation header should refresh itself',
+    help        => q`
+      The navigation header contains the general status information about server load and storage space.
+      `,
+    type        => $types{integer},
+    category    => 'highband',
+  },
+  {
     name        => 'ZM_WEB_H_REFRESH_CYCLE',
     default     => '10',
     description => 'How often (in seconds) the cycle watch window swaps to the next monitor',
@@ -3197,6 +3207,16 @@ our @options = (
     category    => 'medband',
   },
   {
+    name        => 'ZM_WEB_M_REFRESH_NAVBAR',
+    default     => '15',
+    description => 'How often (in seconds) the navigation header should refresh itself',
+    help        => q`
+      The navigation header contains the general status information about server load and storage space.
+      `,
+    type        => $types{integer},
+    category    => 'medband',
+  },
+  {
     name        => 'ZM_WEB_M_REFRESH_CYCLE',
     default     => '20',
     description => 'How often (in seconds) the cycle watch window swaps to the next monitor',
@@ -3455,6 +3475,16 @@ our @options = (
       totals for all monitors. This is not a trivial task and should
       not be repeated too frequently or it may affect the performance
       of the rest of the system.
+      `,
+    type        => $types{integer},
+    category    => 'lowband',
+  },
+  {
+    name        => 'ZM_WEB_L_REFRESH_NAVBAR',
+    default     => '35',
+    description => 'How often (in seconds) the navigation header should refresh itself',
+    help        => q`
+      The navigation header contains the general status information about server load and storage space.
       `,
     type        => $types{integer},
     category    => 'lowband',

--- a/web/ajax/status.php
+++ b/web/ajax/status.php
@@ -1,4 +1,8 @@
 <?php
+if ($_REQUEST['entity'] == "navBar") {
+   ajaxResponse(getNavBarHtml('reload'));
+   return;
+}
 
 $statusData = array(
     'system' => array(

--- a/web/skins/classic/includes/config.php
+++ b/web/skins/classic/includes/config.php
@@ -56,6 +56,7 @@ $bandwidth_options = array(
 switch ( $_COOKIE['zmBandwidth'] ) {
     case 'high' : {
         define( 'ZM_WEB_REFRESH_MAIN', ZM_WEB_H_REFRESH_MAIN );         // How often (in seconds) the main console window refreshes
+        define( 'ZM_WEB_REFRESH_NAVBAR', ZM_WEB_H_REFRESH_NAVBAR );     // How often (in seconds) the nav header refreshes
         define( 'ZM_WEB_REFRESH_CYCLE', ZM_WEB_H_REFRESH_CYCLE );       // How often the cycle watch windows swaps to the next monitor
         define( 'ZM_WEB_REFRESH_IMAGE', ZM_WEB_H_REFRESH_IMAGE );       // How often the watched image is refreshed (if not streaming)
         define( 'ZM_WEB_REFRESH_STATUS', ZM_WEB_H_REFRESH_STATUS );     // How often the little status frame refreshes itself in the watch window
@@ -73,6 +74,7 @@ switch ( $_COOKIE['zmBandwidth'] ) {
         break;
     } case 'medium' : {
         define( 'ZM_WEB_REFRESH_MAIN', ZM_WEB_M_REFRESH_MAIN );         // How often (in seconds) the main console window refreshes
+        define( 'ZM_WEB_REFRESH_NAVBAR', ZM_WEB_M_REFRESH_NAVBAR );     // How often (in seconds) the nav header refreshes
         define( 'ZM_WEB_REFRESH_CYCLE', ZM_WEB_M_REFRESH_CYCLE );       // How often the cycle watch windows swaps to the next monitor
         define( 'ZM_WEB_REFRESH_IMAGE', ZM_WEB_M_REFRESH_IMAGE );       // How often the watched image is refreshed (if not streaming)
         define( 'ZM_WEB_REFRESH_STATUS', ZM_WEB_M_REFRESH_STATUS );     // How often the little status frame refreshes itself in the watch window
@@ -90,6 +92,7 @@ switch ( $_COOKIE['zmBandwidth'] ) {
         break;
     } case 'low' : {
         define( 'ZM_WEB_REFRESH_MAIN', ZM_WEB_L_REFRESH_MAIN );         // How often (in seconds) the main console window refreshes
+        define( 'ZM_WEB_REFRESH_NAVBAR', ZM_WEB_L_REFRESH_NAVBAR );     // How often (in seconds) the nav header refreshes
         define( 'ZM_WEB_REFRESH_CYCLE', ZM_WEB_L_REFRESH_CYCLE );       // How often the cycle watch windows swaps to the next monitor
         define( 'ZM_WEB_REFRESH_IMAGE', ZM_WEB_L_REFRESH_IMAGE );       // How often the watched image is refreshed (if not streaming)
         define( 'ZM_WEB_REFRESH_STATUS', ZM_WEB_L_REFRESH_STATUS );     // How often the little status frame refreshes itself in the watch window

--- a/web/skins/classic/includes/functions.php
+++ b/web/skins/classic/includes/functions.php
@@ -162,26 +162,21 @@ if ( file_exists( "skins/$skin/css/$css/graphics/favicon.ico" ) ) {
 function getNavBarHTML($reload = null) {
 
   $versionClass = (ZM_DYN_DB_VERSION&&(ZM_DYN_DB_VERSION!=ZM_VERSION))?'errorText':'';
-
-
-  ob_start();
   global $running;
-  if ( $running == null )
-    $running = daemonCheck();
-  $status = $running?translate('Running'):translate('Stopped');
   global $user;
   global $bandwidth_options;
   global $view;
 if ($reload === null) {
+    ob_start();
+    if ( $running == null )
+      $running = daemonCheck();
+    $status = $running?translate('Running'):translate('Stopped');
 ?>
 <noscript>
 <div style="background-color:red;color:white;font-size:x-large;">
 ZoneMinder requires Javascript. Please enable Javascript in your browser for this site.
 </div>
 </noscript>
-<?php
-}
-?>
 <div class="navbar navbar-inverse navbar-static-top">
 	<div class="container-fluid">
 		<div class="navbar-header">
@@ -246,7 +241,11 @@ if ( ZM_OPT_X10 && canView( 'Devices' ) ) { ?>
 </div>
 		</div><!-- End .navbar-collapse -->
 	</div> <!-- End .container-fluid -->
-	<div class="container-fluid">
+<?php
+}//end reload null.  Runs on full page load
+if ($reload == 'reload') ob_start();
+?>
+	<div id="reload" class="container-fluid">
   <div class="pull-left">
     <?php echo makePopupLink( '?view=bandwidth', 'zmBandwidth', 'bandwidth', $bandwidth_options[$_COOKIE['zmBandwidth']] . ' ' . translate('BandwidthHead'), ($user && $user['MaxBandwidth'] != 'low' ) ) ?>
   </div>
@@ -280,9 +279,11 @@ if ( ZM_OPT_X10 && canView( 'Devices' ) ) { ?>
   echo ' ' . ZM_PATH_MAP .': '. getDiskPercent(ZM_PATH_MAP).'%';
 ?></li>
   </ul>
-</div> <!-- End .footer -->
-
-<!-- End .navbar .navbar-default --></div>
+</div> <!-- End .footer/reload -->
+<?php
+if ($reload == 'reload') return( ob_get_clean() );
+?>
+</div><!-- End .navbar .navbar-default -->
 <?php
   return( ob_get_clean() );
 } // end function getNavBarHTML()

--- a/web/skins/classic/includes/functions.php
+++ b/web/skins/classic/includes/functions.php
@@ -159,7 +159,7 @@ if ( file_exists( "skins/$skin/css/$css/graphics/favicon.ico" ) ) {
 <?php
 } // end function xhtmlHeaders( $file, $title )
 
-function getNavBarHTML() {
+function getNavBarHTML($reload = null) {
 
   $versionClass = (ZM_DYN_DB_VERSION&&(ZM_DYN_DB_VERSION!=ZM_VERSION))?'errorText':'';
 
@@ -172,13 +172,16 @@ function getNavBarHTML() {
   global $user;
   global $bandwidth_options;
   global $view;
+if ($reload === null) {
 ?>
 <noscript>
 <div style="background-color:red;color:white;font-size:x-large;">
 ZoneMinder requires Javascript. Please enable Javascript in your browser for this site.
 </div>
 </noscript>
-
+<?php
+}
+?>
 <div class="navbar navbar-inverse navbar-static-top">
 	<div class="container-fluid">
 		<div class="navbar-header">
@@ -279,7 +282,7 @@ if ( ZM_OPT_X10 && canView( 'Devices' ) ) { ?>
   </ul>
 </div> <!-- End .footer -->
 
-</div> <!-- End .navbar .navbar-default -->
+<!-- End .navbar .navbar-default --></div>
 <?php
   return( ob_get_clean() );
 } // end function getNavBarHTML()

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -182,6 +182,20 @@ function refreshParentWindow() {
   }
 }
 
+$j.ajaxSetup ({timeout: AJAX_TIMEOUT }); //sets timeout for all getJSON.
+
+$j(document).ready(function() {
+  if ($j('.navbar').length) setInterval(getNavBar, navBarRefresh)
+});
+
+function getNavBar () {
+  $j.getJSON(thisUrl + '?view=request&request=status&entity=navBar', setNavBar);
+}
+
+function setNavBar (data) {
+  $j('.navbar').replaceWith(data.message);
+}
+
 //Shows a message if there is an error in the streamObj or the stream doesn't exist.  Returns true if error, false otherwise.
 function checkStreamForErrors( funcName, streamObj ) {
   if ( !streamObj ) {

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -193,7 +193,7 @@ function getNavBar () {
 }
 
 function setNavBar (data) {
-  $j('.navbar').replaceWith(data.message);
+  $j('#reload').replaceWith(data.message);
 }
 
 //Shows a message if there is an error in the streamObj or the stream doesn't exist.  Returns true if error, false otherwise.

--- a/web/skins/classic/js/skin.js.php
+++ b/web/skins/classic/js/skin.js.php
@@ -26,6 +26,8 @@
 ?>
 var AJAX_TIMEOUT = <?php echo ZM_WEB_AJAX_TIMEOUT ?>;
 
+var navBarRefresh = <?php echo 1000*ZM_WEB_REFRESH_NAVBAR ?>;
+
 var currentView = '<?php echo $view ?>';
 var thisUrl = "<?php echo ZM_BASE_URL.$_SERVER['PHP_SELF'] ?>";
 var skinPath = "<?php echo ZM_SKIN_PATH ?>";

--- a/web/skins/classic/views/js/event.js
+++ b/web/skins/classic/views/js/event.js
@@ -40,8 +40,6 @@ function vjsReplay() {
   }
 }
 
-$j.ajaxSetup ({timeout: AJAX_TIMEOUT }); //sets timeout for all getJSON.
-
 var cueFrames = null; //make cueFrames availaible even if we don't send another ajax query
 
 function initialAlarmCues (eventId) {


### PR DESCRIPTION
Adds a refresh to the navbar header with options to set the frequency in the web bandwidth config page.  Should only run on pages with the navbar.

I think I got all the config additions correct but I'm not entirely sure.