### PR TITLE
Montagereview filter respect groups setting

### DIFF
--- a/web/skins/classic/includes/export_functions.php
+++ b/web/skins/classic/includes/export_functions.php
@@ -908,9 +908,9 @@ function exportEvents( $eids, $exportDetail, $exportFrames, $exportImages, $expo
             $archive = ZM_DIR_EXPORTS."/".$export_root.".tar.gz";
             @unlink( $archive );
             if ($exportStructure == 'flat') {  //strip file paths if we choose
-              $command = "tar --create --gzip --file=".escapeshellarg($archive)." --files-from=".escapeshellarg($listFile)." --xform='s#^.+/##x'";
+              $command = "nice -10 tar --create --gzip --file=".escapeshellarg($archive)." --files-from=".escapeshellarg($listFile)." --xform='s#^.+/##x'";
             } else {
-              $command = "tar --create --gzip --file=".escapeshellarg($archive)." --files-from=".escapeshellarg($listFile);
+              $command = "nice -10 tar --create --gzip --file=".escapeshellarg($archive)." --files-from=".escapeshellarg($listFile);
             }
             exec( $command, $output, $status );
             if ( $status )
@@ -926,9 +926,9 @@ function exportEvents( $eids, $exportDetail, $exportFrames, $exportImages, $expo
             $archive = ZM_DIR_EXPORTS."/".$export_root.".zip";
             @unlink( $archive );
             if ($exportStructure == 'flat') {
-              $command = "cat ".escapeshellarg($listFile)." | zip -q -j ".escapeshellarg($archive)." -@";
+              $command = "cat ".escapeshellarg($listFile)." | nice -10 zip -q -j ".escapeshellarg($archive)." -@";
             } else {
-              $command = "cat ".escapeshellarg($listFile)." | zip -q ".escapeshellarg($archive)." -@";
+              $command = "cat ".escapeshellarg($listFile)." | nice -10 zip -q ".escapeshellarg($archive)." -@";
             }
 //cat zmFileList.txt | zip -q zm_export.zip -@
 //-bash: zip: command not found

--- a/web/skins/classic/js/skin.js
+++ b/web/skins/classic/js/skin.js
@@ -182,18 +182,20 @@ function refreshParentWindow() {
   }
 }
 
-$j.ajaxSetup ({timeout: AJAX_TIMEOUT }); //sets timeout for all getJSON.
+if (currentView !='none') {
+  $j.ajaxSetup ({timeout: AJAX_TIMEOUT }); //sets timeout for all getJSON.
 
-$j(document).ready(function() {
-  if ($j('.navbar').length) setInterval(getNavBar, navBarRefresh)
-});
+  $j(document).ready(function() {
+    if ($j('.navbar').length) setInterval(getNavBar, navBarRefresh)
+  });
 
-function getNavBar () {
-  $j.getJSON(thisUrl + '?view=request&request=status&entity=navBar', setNavBar);
-}
+  function getNavBar () {
+    $j.getJSON(thisUrl + '?view=request&request=status&entity=navBar', setNavBar);
+  }
 
-function setNavBar (data) {
-  $j('#reload').replaceWith(data.message);
+  function setNavBar (data) {
+    $j('#reload').replaceWith(data.message);
+  }
 }
 
 //Shows a message if there is an error in the streamObj or the stream doesn't exist.  Returns true if error, false otherwise.

--- a/web/skins/classic/views/download.php
+++ b/web/skins/classic/views/download.php
@@ -23,16 +23,18 @@ if ( !canView( 'Events' ) ) {
   return;
 }
 
-if (isset($_REQUEST['filter'])) { //Handles montageReview filter
+if (isset($_SESSION['montageReviewFilter'])) { //Handles montageReview filter
   $eventsSql = 'SELECT E.Id FROM Events as E WHERE 1';
-  parseFilter($_REQUEST['filter']);
-  $eventsSql .= $_REQUEST['filter']['sql'];
+  $eventsSql .= $_SESSION['montageReviewFilter']['sql'];
   $results = dbQuery($eventsSql);
   $eids = [];
   while ( $event_row = dbFetchNext( $results ) ) {
     array_push($eids, 'eids[]='.$event_row['Id']);
   }
   $_REQUEST['eids'] = $eids;
+  session_start();
+  unset($_SESSION['montageReviewFilter']);
+  session_write_close();
 }
 
 $focusWindow = true;

--- a/web/skins/classic/views/js/montagereview.js
+++ b/web/skins/classic/views/js/montagereview.js
@@ -335,7 +335,7 @@ function redrawScreen() {
         $('zoomout').style.display="none";
         $('panleft').style.display="none";
         $('panright').style.display="none";
-        $('downloadVideo').style.display="none";
+        if ($('downloadVideo')) $('downloadVideo').style.display="none";
 
     } else  {
     // switch out of liveview mode
@@ -352,7 +352,7 @@ function redrawScreen() {
         $('panleft').style.display="inline-flex";
         $('panright').style.display="inline";
         $('panright').style.display="inline-flex";
-        $('downloadVideo').style.display="inline";
+        if ($('downloadVideo')) $('downloadVideo').style.display="inline";
     }
 
     if ( fitMode == 1 ) {
@@ -556,7 +556,7 @@ function click_panright() {
   clicknav(minTimeSecs,maxTimeSecs,0);
 }
 function click_download() {
-  createPopup( '?view=download'+filterQuery, 'zmDownload', 'download' );
+  createPopup( '?view=download', 'zmDownload', 'download' );
 }
 function click_all_events() {
   clicknav(0,0,0);

--- a/web/skins/classic/views/js/montagereview.js.php
+++ b/web/skins/classic/views/js/montagereview.js.php
@@ -1,6 +1,4 @@
 
-var filterQuery = '<?php echo isset($filterQuery)?htmlspecialchars_decode($filterQuery):'' ?>';
-
 var server_utc_offset = <?php
 $TimeZone = new DateTimeZone( ini_get('date.timezone') );
 $now = new DateTime('now', $TimeZone);


### PR DESCRIPTION
Download button in montagereview should now respect group/monitor/status/server settings.  I don't have a multi-server setup to test it so I can't say for sure.  I used $_SESSION to pass the filter information because with many cameras the url could overflow.  This caused me some difficulty with populating the filter window from montage review so that is removed until I can figure it out.  

Added nice to the archive commands to avoid locking the server while archives are generated.