### PR TITLE
Fix missing change to StartDateTime

### DIFF
--- a/web/skins/classic/views/console.php
+++ b/web/skins/classic/views/console.php
@@ -37,7 +37,7 @@ $eventCounts = array(
     'filter' => array(
       'Query' => array(
         'terms' => array(
-          array( 'attr' => 'DateTime', 'op' => '>=', 'val' => '-1 hour' ),
+          array( 'attr' => 'StartDateTime', 'op' => '>=', 'val' => '-1 hour' ),
         )
       )
     ),


### PR DESCRIPTION
Fixes filter loading from events if clicked from last hour link.  All other console page links were changed, looks like this one was missed.