### PR TITLE
changing the querySep in Event.php to allow gapless playback

### DIFF
--- a/web/includes/Event.php
+++ b/web/includes/Event.php
@@ -158,7 +158,7 @@ class Event {
     } # ! ZM_OPT_FAST_DELETE
   } # end Event->delete
 
-  public function getStreamSrc( $args=array(), $querySep='&amp;' ) {
+  public function getStreamSrc( $args=array(), $querySep='&' ) {
     if ( $this->{'DefaultVideo'} and $args['mode'] != 'jpeg' ) {
       $streamSrc = ZM_BASE_PROTOCOL.'://';
       $Monitor = $this->Monitor();


### PR DESCRIPTION
To address https://github.com/connortechnology/ZoneMinder/issues/85 

I modified this on my own server and everything appears to be working properly at this time. I don't think this will affect anything else. 