### PR TITLE
added "Require all granted" to cache directory

### DIFF
--- a/distros/ubuntu1604/conf/apache2/zoneminder.conf
+++ b/distros/ubuntu1604/conf/apache2/zoneminder.conf
@@ -10,6 +10,7 @@ ScriptAlias /zm/cgi-bin "/usr/lib/zoneminder/cgi-bin"
 Alias /zm/cache /var/cache/zoneminder/cache
 <Directory /var/cache/zoneminder/cache>
   Options -Indexes +FollowSymLinks
+  Require all granted
 </Directory>
 
 Alias /zm /usr/share/zoneminder/www


### PR DESCRIPTION
Ever since the cache directory was introduced in zoneminder.conf for Apache, the `Require all granted` directive was missing, and thus no CSS was loaded.