### PR TITLE
Adding support for HTTP_X_FORWARDED_PROTO

### DIFF
--- a/web/index.php
+++ b/web/index.php
@@ -51,6 +51,8 @@ require_once( 'includes/Event.php' );
 require_once( 'includes/Group.php' );
 require_once( 'includes/Monitor.php' );
 
+if ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') $_SERVER['HTTPS']='on';
+
 if ( isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on' ) {
   $protocol = 'https';
 } else {


### PR DESCRIPTION
adding support tor HTTP_X_FORWARDED_PROTO so it will correctly set https if reverse proxy is https but zoneminder server isn't.