### PR TITLE
Deal with Error for Auto not in Array

### DIFF
--- a/web/skins/classic/views/monitor.php
+++ b/web/skins/classic/views/monitor.php
@@ -972,7 +972,7 @@ echo htmlSelect('newMonitor[OutputCodec]', $videowriter_codecs, $monitor->Output
               <td>
 <?php
 $videowriter_encoders = array(
-  '' => translate('Auto'),
+  'auto' => translate('Auto'),
   'h264_omx' => 'h264_omx',
   'libx264' => 'libx264',
   'h264_vaapi' => 'h264_vaapi',


### PR DESCRIPTION
Add value auto into the array, even if not implemented as without it you cannot save a monitor.